### PR TITLE
Fix no current renderer

### DIFF
--- a/dipy/viz/window.py
+++ b/dipy/viz/window.py
@@ -449,6 +449,7 @@ class ShowManager(object):
 
         self.iren.AddObserver('KeyPressEvent', key_press_standard)
         self.iren.SetInteractorStyle(self.style)
+        self.style.SetCurrentRenderer(self.ren)
 
         self.picker = vtk.vtkCellPicker()
         self.picker.SetTolerance(self.picker_tol)


### PR DESCRIPTION
This fixes the "no current renderer on the interactor style" vtk warning.
