### PR TITLE
Switch to QBx in recobundles

### DIFF
--- a/dipy/tracking/__init__.py
+++ b/dipy/tracking/__init__.py
@@ -1,6 +1,6 @@
 # Init for tracking module
 """ Tracking objects """
-from nibabel.streamlines import CompactList as Streamlines
+from nibabel.streamlines import ArraySequence as Streamlines
 
 # Test callable
 from numpy.testing import Tester


### PR DESCRIPTION
- Remplace every call to QB by QBx
- Now use ArraySequence instead of CompactList
- Bug fix : close_streamlines was a list instead of an ArraySequence
- Bug fix : replace transform_streamlines() to apply_affine() to keep an ArraySequence
